### PR TITLE
Optimizing Unity Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ sysinfo.txt
 # Crashlytics generated file
 crashlytics-build.properties
 
+.vsconfig

--- a/Assets/Plugins/Android/mainTemplate.gradle
+++ b/Assets/Plugins/Android/mainTemplate.gradle
@@ -8,16 +8,16 @@
             url "https://maven.google.com"
         }
         maven {
-            url "https://dl.bintray.com/yodo1/MAS-Android" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:12
+            url "https://android-sdk.is.com" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:9
         }
         maven {
-            url "https://dl.bintray.com/yodo1/android-sdk" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:12
+            url "http://nexus.yodo1.com:8081/repository/maven-yodo1mas-preview/" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:9
         }
         maven {
-            url "https://android-sdk.is.com" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:12
+            url "https://artifact.bytedance.com/repository/pangle/" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:9
         }
         maven {
-            url "https://fyber.bintray.com/marketplace" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:12
+            url "https://sdk.tapjoy.com/" // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:9
         }
         mavenLocal()
         jcenter()
@@ -31,7 +31,7 @@ apply plugin: 'com.android.library'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 // Android Resolver Dependencies Start
-    implementation 'com.yodo1.mas:full:4.1.0' // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:13
+    implementation 'com.yodo1.mas:full:4.2.0-beta-5d2d260' // Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml:10
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/Assets/Yodo1/MAS/Command.meta
+++ b/Assets/Yodo1/MAS/Command.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2831905bf662643a99461c1481ada00b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Yodo1/MAS/Command/open_repo_update.command
+++ b/Assets/Yodo1/MAS/Command/open_repo_update.command
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "`dirname "$0"`"
+open pods_repo_update.command

--- a/Assets/Yodo1/MAS/Command/open_repo_update.command.meta
+++ b/Assets/Yodo1/MAS/Command/open_repo_update.command.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c419c243ed0b54989878c89465d8fb8b
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Yodo1/MAS/Command/pods_repo_update.command
+++ b/Assets/Yodo1/MAS/Command/pods_repo_update.command
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "`dirname "$0"`"
+pod install --repo-update

--- a/Assets/Yodo1/MAS/Command/pods_repo_update.command.meta
+++ b/Assets/Yodo1/MAS/Command/pods_repo_update.command.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e5411b6a16e19484a80bb26b54b357ab
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml
+++ b/Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasAndroidDependencies.xml
@@ -2,14 +2,11 @@
 <dependencies>
 	<androidPackages>
 		<repositories>
-			<repository>https://dl.bintray.com/yodo1/MAS-Android</repository>
-			<repository>https://dl.bintray.com/yodo1/android-sdk</repository>
 			<repository>https://android-sdk.is.com</repository>
-			<!-- <repository>https://dl.bintray.com/mintegral-official/mintegral_ad_sdk_android_for_oversea</repository>
-			<repository>https://dl.bintray.com/mintegral-official/Andorid_ad_SDK_for_china</repository> -->
-			<repository>https://fyber.bintray.com/marketplace</repository>
-			<!-- <repository>http://nexus.yodo1.com:8081/repository/maven-yodo1mas-preview/</repository> -->
+			<repository>http://nexus.yodo1.com:8081/repository/maven-yodo1mas-preview/</repository>
+			<repository>https://artifact.bytedance.com/repository/pangle/</repository>
+			<repository>https://sdk.tapjoy.com/</repository>
 		</repositories>
-		<androidPackage spec="com.yodo1.mas:full:4.1.0" />
+		<androidPackage spec="com.yodo1.mas:full:4.2.0-beta-5d2d260" />
 	</androidPackages>
 </dependencies>

--- a/Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasiOSDependencies.xml
+++ b/Assets/Yodo1/MAS/Editor/Dependencies/Yodo1MasiOSDependencies.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
-    <iosPods>
-        <sources>
-            <!-- <source>https://github.com/Yodo1Games/MAS-Spec-Pre.git</source> -->
-            <source>https://github.com/Yodo1Games/MAS-Spec.git</source>
-            <source>https://github.com/Yodo1Games/Yodo1Spec.git</source>
-        </sources>
-        <iosPod name="FBSDKCoreKit" version="7.0.1" bitcode="false" minTargetSdk="9.0" />
-        <iosPod name="Yodo1MasFull" version="4.1.0" bitcode="false" minTargetSdk="9.0" />
-    </iosPods>
+	<iosPods>
+		<sources>
+			<source>https://github.com/Yodo1Games/MAS-Spec-Pre.git</source>
+			<!--            <source>https://github.com/Yodo1Games/MAS-Spec.git</source>-->
+			<source>https://github.com/Yodo1Games/Yodo1Spec.git</source>
+		</sources>
+		<iosPod name="FBSDKCoreKit" version="7.0.1" bitcode="false" minTargetSdk="9.0" />
+		<iosPod name="Yodo1MasFull" version="4.2.0-beta-8996c0f" bitcode="false" minTargetSdk="9.0" />
+	</iosPods>
 </dependencies>

--- a/Assets/Yodo1/MAS/Editor/Scripts/Yodo1AdPostprocess.cs
+++ b/Assets/Yodo1/MAS/Editor/Scripts/Yodo1AdPostprocess.cs
@@ -47,6 +47,7 @@ namespace Yodo1.MAS
             "u679fj5vs4.skadnetwork",
             "uw77j35x4d.skadnetwork",
             "v72qych5uu.skadnetwork",
+            "wg4vff78zm.skadnetwork",
             "yclnxrl5pm.skadnetwork",
             "2fnua5tdw4.skadnetwork",
             "3qcr597p9d.skadnetwork",
@@ -57,21 +58,16 @@ namespace Yodo1.MAS
             "av6w8kgt66.skadnetwork",
             "cstr6suwn9.skadnetwork",
             "e5fvkxwrpn.skadnetwork",
-            "ecpz2srf59.skadnetwork",
             "f38h382jlk.skadnetwork",
-            "hjevpa356n.skadnetwork",
-            "k674qkevps.skadnetwork",
             "kbd757ywx3.skadnetwork",
-            "ludvb6z3bs.skadnetwork",
             "n6fk4nfna4.skadnetwork",
             "p78axxw29g.skadnetwork",
             "s39g8k73mm.skadnetwork",
-            "v9wttpbfk9.skadnetwork",
             "wzmmz9fp6w.skadnetwork",
-            "y2ed4ez56y.skadnetwork",
             "ydx93a7ass.skadnetwork",
             "zq492l623r.skadnetwork",
             "24t9a8vw3c.skadnetwork",
+            "294l99pt4k.skadnetwork",
             "32z4fx6l9h.skadnetwork",
             "523jb4fst2.skadnetwork",
             "54nzkqm89y.skadnetwork",
@@ -85,33 +81,42 @@ namespace Yodo1.MAS
             "ggvn48r87g.skadnetwork",
             "glqzh8vgby.skadnetwork",
             "gta9lk7p23.skadnetwork",
+            "k674qkevps.skadnetwork",
+            "kbmxgpxpgc.skadnetwork",
+            "ludvb6z3bs.skadnetwork",
             "n9x2a789qt.skadnetwork",
             "pwa73g5rt2.skadnetwork",
-            "wg4vff78zm.skadnetwork",
+            "r45fhb6rf7.skadnetwork",
+            "rvh3l7un93.skadnetwork",
+            "x8jxxk4ff5.skadnetwork",
             "xy9t38ct57.skadnetwork",
             "zmvfpc5aq8.skadnetwork",
             "n38lu8286q.skadnetwork",
+            "v9wttpbfk9.skadnetwork",
+            "22mmun2rn5.skadnetwork",
             "252b5q8x7y.skadnetwork",
             "9g2aggbj52.skadnetwork",
             "dzg6xy7pwj.skadnetwork",
             "f73kdq92p3.skadnetwork",
             "hdw39hrw9y.skadnetwork",
+            "x8uqf25wch.skadnetwork",
             "y45688jllp.skadnetwork",
+            "97r2b46745.skadnetwork",
+            "b9bk5wbcq9.skadnetwork",
+            "mls7yz5dvl.skadnetwork",
             "w9q455wk68.skadnetwork",
             "su67r6k2v3.skadnetwork",
             "737z793b9f.skadnetwork",
             "r26jy69rpl.skadnetwork",
-            "22mmun2rn5.skadnetwork",
             "238da6jt44.skadnetwork",
             "44n7hlldy6.skadnetwork",
             "488r3q3dtq.skadnetwork",
             "52fl2v3hgk.skadnetwork",
             "5tjdwbrq8w.skadnetwork",
-            "97r2b46745.skadnetwork",
             "9yg77x724h.skadnetwork",
+            "ecpz2srf59.skadnetwork",
             "gvmwg8q7h5.skadnetwork",
             "lr83yxwka7.skadnetwork",
-            "mls7yz5dvl.skadnetwork",
             "n66cz3y3bx.skadnetwork",
             "nzq8sh4pbs.skadnetwork",
             "pu4na253f3.skadnetwork",
@@ -119,9 +124,10 @@ namespace Yodo1.MAS
             "yrqqpx2mcb.skadnetwork",
             "z4gj7hsk7h.skadnetwork",
             "4dzt52r2t5.skadnetwork",
-            "bvpn9ufa9b.skadnetwork",
             "f7s53z58qe.skadnetwork",
-            "7953jerfzd.skadnetwork"
+            "mp6xlyr22a.skadnetwork",
+            "x44k69ngh6.skadnetwork",
+            "7953jerfzd.skadnetwork",
         };
 
         [PostProcessBuild()]
@@ -135,6 +141,8 @@ namespace Yodo1.MAS
                 {
                     UpdateIOSPlist(pathToBuiltProject, settings);
                     UpdateIOSProject(pathToBuiltProject);
+                    CopyDirectory("Assets/Yodo1/MAS/Command/", pathToBuiltProject, null);
+                    StartPodsProcess(pathToBuiltProject, "open_repo_update.command");
                 }
 #endif
             }
@@ -151,6 +159,13 @@ namespace Yodo1.MAS
                 }
 #endif
             }
+        }
+
+        public static void StartPodsProcess(string path, string podcommand)
+        {
+            var proc = new System.Diagnostics.Process();
+            proc.StartInfo.FileName = Path.Combine(path, podcommand);
+            proc.Start();
         }
 
         #region iOS Content

--- a/Assets/Yodo1/MAS/Editor/Scripts/Yodo1AdWindows.cs
+++ b/Assets/Yodo1/MAS/Editor/Scripts/Yodo1AdWindows.cs
@@ -6,13 +6,12 @@ using System.IO;
 using System.Net;
 using System.Text;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using UnityEngine.Networking;
 using System.Collections;
 
 namespace Yodo1.MAS
 {
-  
+
     public class Yodo1AdWindows : EditorWindow
     {
         private static string app_key = string.Empty;
@@ -106,7 +105,7 @@ namespace Yodo1.MAS
             if (!string.IsNullOrEmpty(appKey))
             {
                 string api = "https://sdk.mas.yodo1.com/v1/unity/setup/" + appKey;
-#if UNITY_2018
+#if UNITY_2018_1_OR_NEWER
                 string response = HttpGet(api);
                 Dictionary<string, object> obj = (Dictionary<string, object>)Yodo1JSON.Deserialize(response);
                 Debug.Log("response:" + response);
@@ -147,7 +146,7 @@ namespace Yodo1.MAS
                     result = "MAS App Key not found. please fill in correctly.";
                 }
 #else
-                ApiCallback callback = delegate(string response)
+                ApiCallback callback = delegate (string response)
                 {
                     Dictionary<string, object> obj = (Dictionary<string, object>)Yodo1JSON.Deserialize(response);
                     Debug.Log("response:" + response);
@@ -188,7 +187,7 @@ namespace Yodo1.MAS
                         result = "MAS App Key not found. please fill in correctly.";
                     }
 
-                }; 
+                };
                 EditorCoroutineRunner.StartEditorCoroutine(SendUrl(api, callback));
 #endif
             }
@@ -221,7 +220,7 @@ namespace Yodo1.MAS
             GUILayout.EndScrollView();
         }
 
-#endregion
+        #endregion
 
         private void DrawContent()
         {
@@ -442,7 +441,8 @@ namespace Yodo1.MAS
                 }
                 else
                 {
-                    callback?.Invoke(www.text);
+                    //callback?.Invoke(www.text);
+                    callback(www.text);
                 }
             }
         }

--- a/Assets/Yodo1/MAS/Sample/Yodo1AdsTest.cs
+++ b/Assets/Yodo1/MAS/Sample/Yodo1AdsTest.cs
@@ -82,7 +82,8 @@ public class Yodo1AdsTest : MonoBehaviour
 
             if (success)
             {
-                StartCoroutine(BannerCoroutine());
+                //StartCoroutine(BannerCoroutine());
+                Yodo1U3dMas.ShowBannerAd();
             }
             else
             {
@@ -147,22 +148,22 @@ public class Yodo1AdsTest : MonoBehaviour
         });
     }
 
-    bool isBannerShown = false;
+    //bool isBannerShown = false;
 
-    IEnumerator BannerCoroutine()
-    {
-        yield return new WaitForSeconds(2.0f);
-        if (isBannerShown == false)
-        {
-            if (Yodo1U3dMas.IsBannerAdLoaded())
-            {
-                Yodo1U3dMas.ShowBannerAd();
-            }
-            else
-            {
-                StartCoroutine(BannerCoroutine());
-            }
-        }
+    //IEnumerator BannerCoroutine()
+    //{
+    //    yield return new WaitForSeconds(2.0f);
+    //    if (isBannerShown == false)
+    //    {
+    //        if (Yodo1U3dMas.IsBannerAdLoaded())
+    //        {
+    //            Yodo1U3dMas.ShowBannerAd();
+    //        }
+    //        else
+    //        {
+    //            StartCoroutine(BannerCoroutine());
+    //        }
+    //    }
 
-    }
+    //}
 }

--- a/Assets/Yodo1/MAS/Version.md
+++ b/Assets/Yodo1/MAS/Version.md
@@ -1,6 +1,6 @@
 ## Versions
 
-## 4.1.0
+## 4.2.0-beta-2c43b03
 
-Android: 4.1.0
-iOS: 4.1.0
+Android: 4.2.0-beta-5d2d260
+iOS: 4.2.0-beta-8996c0f

--- a/ProjectSettings/AndroidResolverDependencies.xml
+++ b/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,6 +1,6 @@
 <dependencies>
   <packages>
-    <package>com.yodo1.mas:full:4.1.0</package>
+    <package>com.yodo1.mas:full:4.2.0-beta-5d2d260</package>
   </packages>
   <files />
   <settings>


### PR DESCRIPTION
The optimized content is as follows
1. ShowBanner method optimization
2. IOS automates the execution of commands "pod install --repo-update"
3. The plugin no longer mandatory the use of .NET 4.x

For #1, added an enhancement to the SDK's showBanner method so the showBanner method can display banner ads automatically when banner ad is loaded 
For #2, added the command "pod install --repo-update" to the MAS Unity plugin. The command will be executed when the iOS project is generated to avoid compilation errors caused by the loss of SDK
For #3, in MAS 4.1.0, developers will experience compilation errors if they do not use.NET 4.x. In MAS 4.2.0, we have optimized the code so that it is no longer mandatory .NET 4. x